### PR TITLE
Update PlatformHelpers.ps1

### DIFF
--- a/WaykAgent/Private/PlatformHelpers.ps1
+++ b/WaykAgent/Private/PlatformHelpers.ps1
@@ -23,11 +23,7 @@ function Get-WindowsHostArch
 function Get-UninstallRegistryKey(
 	[string] $display_name = 'Wayk Agent'
 ){
-    if ([System.Environment]::Is64BitOperatingSystem) {
-        $uninstall_base_reg = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"
-    } else {
-        $uninstall_base_reg = "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall"
-    }
+    $uninstall_base_reg = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall"
 
     return Get-ChildItem $uninstall_base_reg `
         | ForEach-Object { Get-ItemProperty $_.PSPath } | Where-Object { $_ -Match $display_name };


### PR DESCRIPTION
Wayk Agent doesn't allow installation of the x86 version on x64 systems; the uninstall key should never be in the Wow6432 node. And on x86-on-x86 installs, the Wow6432 key is also wrong.